### PR TITLE
Update pr-labeler.yml

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, unlabeled]
 
+  schedule:
+    - cron: "0 3 * * *" # runs daily at 03:00 UTC
+
 jobs:
   add-label:
     runs-on: ubuntu-latest
@@ -13,12 +16,20 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = context.payload.pull_request;
-            if (pr.labels.length === 0) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                labels: ["🔧 other"]
-              });
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open"
+            });
+
+            for (const pr of pulls) {
+              if (pr.labels.length === 0) {
+                console.log(`Adding default label to PR #${pr.number}`);
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: ["🔧 other"]
+                });
+              }
             }


### PR DESCRIPTION
now release drafter will do a nightly sweep to catch unlabelled edit, but please use the PR system anyway!


